### PR TITLE
Debounce and 50 Millisecond Clock

### DIFF
--- a/50milsec.v
+++ b/50milsec.v
@@ -1,0 +1,13 @@
+`timescale 1ns / 1ps
+
+module milsec50(clk, clkSlow);
+    input clk;
+    output clkSlow;
+    
+    reg [21:0] count;
+    
+    assign clkSlow = count[21];
+    always@( posedge clk) begin
+       count = count + 1;
+    end
+endmodule

--- a/Debounce.v
+++ b/Debounce.v
@@ -1,0 +1,19 @@
+`timescale 1ns / 1ps
+
+module Debounce(clk, in, out);
+    input clk;
+    input in;
+    output out;
+
+    reg clkSlow, cleaner, clean, pulse;
+    milsec50(clk, clkSlow);
+    assign out = pulse & clean;
+    always@(posedge clkSlow) begin
+       pulse <= clean;
+   end
+   always@(posedge clk) begin
+       cleaner <= in;
+       clean <= cleaner;
+   end
+   
+endmodule


### PR DESCRIPTION
The debounce follows the topology in class along with the edge detection triggered by a clock moving slightly slower than 50 milliseconds.